### PR TITLE
Curation limit fix

### DIFF
--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -122,7 +122,7 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
         string memory _symbol,
         address _curationPass,
         bool _pause,
-        uint256 _curationLimit,
+        uint256 _curationLimit
     ) external initializer {
         __Ownable_init(_owner);
 

--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -121,7 +121,8 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
         string memory _name,
         string memory _symbol,
         address _curationPass,
-        bool _pause
+        bool _pause,
+        uint256 _curationLimit,
     ) external initializer {
         __Ownable_init(_owner);
 
@@ -133,6 +134,11 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
         if (_pause) {
             _setCurationPaused(_pause);
         }
+
+        if (_curationLimit != 0) {
+            updateCurationLimit(_curationLimit);
+        }
+
     }
 
     function getListings() external view returns (Listing[] memory activeListings) {

--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -65,7 +65,8 @@ interface ICurator {
         string memory _name,
         string memory _symbol,
         address _tokenPass,
-        bool _pause
+        bool _pause,
+        uint256 _curationLimit
     ) external;
 }
 


### PR DESCRIPTION
@iainnash submitting a pull request for a minor update, and including all of my questions + feedback following review of the new code base.

**change:** 
1. added the ability to set the curationLimit into the initialize function. default will still be 0 (infinite), unless someone specifies otherwise upon contract curation. will need this input to be exposed in contract factory as well

**questions/clarifications:**

1. might be a helpful ux thing to allow people to pass in an initial array of structs in the initialize function. that way someone could deploy a new curation contract already preloaded with their curatorial choices (ex: think mixtapes) in one transaction for ultimate smoothness. what do you think? may try to just add this in right now as another pull request...
2. line 171 idToListing[numAdded].curator -> does it even matter what addres you are passing in for curator address in the constructor since it will be overwritten by this update of the value to msg.sender? any gas savings by assigning it to something specific when u pass it in? like maybe if u pass in the msg.sender address, or the 0 address, its cheaper gas wise? just checking from a UX perspective
3. Line 180 why does this check happen after the for loop? does numAdded being incremented on line 177 within the for loop not let you evade this check?
4. How is line 183 ++numAdded not redundant to line 178 ++numAdded
5. line 199 access check on updateSortOrders function -> not sure how I feel with curators being allowed to update the sort orders of their listings. seems like everyone would just max this out to try to get their listings seen before others? I guess it could actually provide the ability for independent curators to sort the relevance of their own listings within the curation contract which could make sense, but feel like the ability to game system may be more prevalent. feel like this could instead be gated to onlyOwner, but then would need to prevent people from passing in something besides 0 for this value on addListing? If we went this route and gated it to onlyOwner, maybe we could also extend it to designated "sortOrderCurator" roles/addresses who had the ability to update the sortOrders for all tokens. not sure here, open to suggestion
6. is _burn in CuratorSkeletonNFT.sol line 74 actually "burning the token out of existence" or just transferring it to the 0x0 address?
7. change line 215 function name "burn" to something like "burnListing" to better explain whats going on here?
8. Does the "burn" function on line 215 not prevent people from calling it on token Ids that don't exist and/or they don't own? Should be set up so you can only burn tokens you own, unless you are the contract owner in which case you can burn anything (really like the id of tokenId #0 representing contract ownership btw)
9. Do we have to prevent negative numbers in updateCurationLimit?

**update prioritization requests:**

1. getting the factory updated + everything deployed to testnet is priority 1 so that @salieflewis can make progress on the curation factory + microplatform vercel deployment standalone UI / flow. ill be trying to get a test curator.sol + curatorskeletonnft deployed tonight but might also need help with that
2. finalize tokenURI + contractURI metadata renderer stuff so that we can test dyanmic svg functionality
3. contract natspec and/or directions for where/how I can help generating the natspec + general docs for this contract if that is helpful
4. local repo set up instructions + deploy scripts