### PR TITLE
Initial listings fix

### DIFF
--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -122,7 +122,7 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
         string memory _symbol,
         address _curationPass,
         bool _pause,
-        uint256 _curationLimit,
+        uint256 _curationLimit
     ) external initializer {
         __Ownable_init(_owner);
 

--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -9,7 +9,7 @@ import { CuratorSkeletonNFT } from "./CuratorSkeletonNFT.sol";
 
 
 interface ICurator {
-    struct Listing {
+    struct  {
         address curatedContract;
         uint96 tokenId;
         address curator;
@@ -66,7 +66,8 @@ interface ICurator {
         string memory _symbol,
         address _tokenPass,
         bool _pause,
-        uint256 _curationLimit
+        uint256 _curationLimit,
+        Listing[] memory _initialLisitngs,
     ) external;
 }
 
@@ -123,7 +124,9 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
         string memory _symbol,
         address _curationPass,
         bool _pause,
-        uint256 _curationLimit
+        uint256 _curationLimit,
+        Listing[] memory _initialListings
+
     ) external initializer {
         __Ownable_init(_owner);
 
@@ -138,6 +141,10 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
 
         if (_curationLimit != 0) {
             updateCurationLimit(_curationLimit);
+        }
+
+        if (_initialListings.length != 0) {
+            addListings(_initialListings);
         }
 
     }

--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -121,7 +121,8 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
         string memory _name,
         string memory _symbol,
         address _curationPass,
-        bool _pause
+        bool _pause,
+        uint256 _curationLimit,
     ) external initializer {
         __Ownable_init(_owner);
 
@@ -133,6 +134,11 @@ contract Curator is UUPS, Ownable, CuratorStorageV1, CuratorSkeletonNFT {
         if (_pause) {
             _setCurationPaused(_pause);
         }
+
+        if (_curationLimit != 0) {
+            updateCurationLimit(_curationLimit);
+        }
+
     }
 
     function getListings() external view returns (Listing[] memory activeListings) {

--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -65,7 +65,8 @@ interface ICurator {
         string memory _name,
         string memory _symbol,
         address _tokenPass,
-        bool _pause
+        bool _pause,
+        uint256 _curationLimit
     ) external;
 }
 


### PR DESCRIPTION
@iainnash submitting a pull request for another minor update. more comprehensive questions + commments found in this [pull request](https://github.com/public-assembly/curation-protocol/pull/3) (with a few diff commits) I submitted earlier

**change:**

1. added the ability to pass in an initial array of Listing structs upon contract initialization (so would be something you pass in to the factory deploy call). that way someone could deploy a new curation contract already preloaded with their curatorial choices (ex: think mixtapes) in one transaction for ultimate smoothness. what do you think? is the commit I referenced in question #1 in this [pull request](https://github.com/public-assembly/curation-protocol/pull/3)