### PR TITLE
DO NOT MERGE!!!! - New access control

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/onchain-modules"]
 	path = lib/onchain-modules
 	url = https://github.com/public-assembly/onchain-modules
+[submodule "lib/onchain"]
+	path = lib/onchain
+	url = https://github.com/public-assembly/onchain

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/micro-onchain-metadata-utils"]
 	path = lib/micro-onchain-metadata-utils
 	url = https://github.com/iainnash/micro-onchain-metadata-utils
+[submodule "lib/onchain-modules"]
+	path = lib/onchain-modules
+	url = https://github.com/public-assembly/onchain-modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "lib/micro-onchain-metadata-utils"]
 	path = lib/micro-onchain-metadata-utils
 	url = https://github.com/iainnash/micro-onchain-metadata-utils
-[submodule "lib/onchain-modules"]
-	path = lib/onchain-modules
-	url = https://github.com/public-assembly/onchain-modules
 [submodule "lib/onchain"]
 	path = lib/onchain
 	url = https://github.com/public-assembly/onchain

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/iainnash/micro-onchain-metadata-utils
 [submodule "lib/onchain-modules"]
 	path = lib/onchain-modules
-	url = https://github.com/public-assembly/onchain-modules
+	url = https://github.com/public--assembly/onchain-modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/iainnash/micro-onchain-metadata-utils
 [submodule "lib/onchain-modules"]
 	path = lib/onchain-modules
-	url = https://github.com/public--assembly/onchain-modules
+	url = https://github.com/public-assembly/onchain-modules

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,3 +2,4 @@ forge-std/=lib/forge-std/src/
 micro-onchain-metadata-utils/=lib/micro-onchain-metadata-utils/src/
 @openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
+onchain-modules/=lib/onchain-modules/tokenized-access-control/src

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,4 +2,4 @@ forge-std/=lib/forge-std/src/
 micro-onchain-metadata-utils/=lib/micro-onchain-metadata-utils/src/
 @openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
-onchain-modules/=lib/onchain-modules/tokenized-access-control/src
+onchain/=lib/onchain/tokenized-access-control/src

--- a/src/Curator.sol
+++ b/src/Curator.sol
@@ -50,8 +50,8 @@ contract Curator is
     /// @notice Modifier that ensures curation functionality is active and not frozen
     modifier onlyActive() {
         if (isPaused 
-            & (IAccessControlRegistry(accessControl).getAccessLevel(address(this), msg.sender) < accessRoles.manager 
-            || msg.sender != owner())
+            && (IAccessControlRegistry(accessControl).getAccessLevel(address(this), msg.sender) < accessRoles.manager 
+            && msg.sender != owner())
         ) {
             revert CURATION_PAUSED();
         } 
@@ -66,9 +66,8 @@ contract Curator is
 
     /// @notice Modifier that restricts entry access to an owner or admin
     modifier onlyOwnerOrAdminAccess() {
-        if (
-            IAccessControlRegistry(accessControl).getAccessLevel(address(this), msg.sender) < accessRoles.admin 
-                && owner() != msg.sender
+        if (IAccessControlRegistry(accessControl).getAccessLevel(address(this), msg.sender) < accessRoles.admin 
+            && owner() != msg.sender
         ) {
             revert ACCESS_NOT_ALLOWED();
         }

--- a/src/CuratorStorageV1.sol
+++ b/src/CuratorStorageV1.sol
@@ -2,10 +2,8 @@
 pragma solidity 0.8.15;
 
 import { ICurator } from "./interfaces/ICurator.sol";
-import { IERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
 import { IMetadataRenderer } from "./interfaces/IMetadataRenderer.sol";
 import { IAccessControlRegistry } from "onchain-modules/interfaces/IAccessControlRegistry.sol";
-
 
 /**
  @notice Curator storage variables contract.
@@ -17,10 +15,6 @@ abstract contract CuratorStorageV1 is ICurator {
 
     /// @notice Standard ERC721 symbol for the curator contract
     string internal contractSymbol;
-
-    // Curation pass as an ERC721 that allows other users to curate.
-    // @notice Address to ERC721 with `balanceOf` function.
-    // IERC721Upgradeable public curationPass;
 
     /// @notice Address of the accessControl contract
     IAccessControlRegistry public accessControl;    

--- a/src/CuratorStorageV1.sol
+++ b/src/CuratorStorageV1.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import { ICurator } from "./interfaces/ICurator.sol";
 import { IMetadataRenderer } from "./interfaces/IMetadataRenderer.sol";
-import { IAccessControlRegistry } from "onchain-modules/interfaces/IAccessControlRegistry.sol";
+import { IAccessControlRegistry } from "onchain/interfaces/IAccessControlRegistry.sol";
 
 /**
  @notice Curator storage variables contract.

--- a/src/CuratorStorageV1.sol
+++ b/src/CuratorStorageV1.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 import { ICurator } from "./interfaces/ICurator.sol";
 import { IERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
 import { IMetadataRenderer } from "./interfaces/IMetadataRenderer.sol";
+import { IAccessControlRegistry } from "onchain-modules/interfaces/IAccessControlRegistry.sol";
 
 
 /**
@@ -17,9 +18,12 @@ abstract contract CuratorStorageV1 is ICurator {
     /// @notice Standard ERC721 symbol for the curator contract
     string internal contractSymbol;
 
-    /// Curation pass as an ERC721 that allows other users to curate.
-    /// @notice Address to ERC721 with `balanceOf` function.
-    IERC721Upgradeable public curationPass;
+    // Curation pass as an ERC721 that allows other users to curate.
+    // @notice Address to ERC721 with `balanceOf` function.
+    // IERC721Upgradeable public curationPass;
+
+    /// @notice Address of the accessControl contract
+    IAccessControlRegistry public accessControl;    
 
     /// Stores virtual mapping array length parameters
     /// @notice Array total size (total size)

--- a/src/interfaces/ICurator.sol
+++ b/src/interfaces/ICurator.sol
@@ -59,9 +59,12 @@ interface ICurator {
     /// @notice Emitted when a listing is removed
     event ListingRemoved(address indexed curator, Listing listing);
 
-    /// @notice The curation pass has been updated for the curation contract
-    /// @dev Any users that have already curated something still can delete their curation.
-    event CurationPassUpdated(address indexed owner, address curationPass);
+    // @notice The curation pass has been updated for the curation contract
+    // @dev Any users that have already curated something still can delete their curation.
+    // event CurationPassUpdated(address indexed owner, address curationPass);
+
+    /// @notice A new accessControl is set
+    event SetAccessControl(address);
 
     /// @notice A new renderer is set
     event SetRenderer(address);
@@ -78,11 +81,11 @@ interface ICurator {
     /// @notice This contract is scheduled to be frozen
     event ScheduledFreeze(uint256 timestamp);
 
-    /// @notice Pass is required to manage curation but not held by attempted updater.
-    error PASS_REQUIRED();
+    // /// @notice Pass is required to manage curation but not held by attempted updater.
+    // error PASS_REQUIRED();
 
-    /// @notice Only the curator of a listing (or owner) can manage that curation
-    error ONLY_CURATOR();
+    // @notice Only the curator of a listing (or owner) can manage that curation
+    // error ONLY_CURATOR();
 
     /// @notice Wrong curator for the listing when attempting to access the listing.
     error WRONG_CURATOR_FOR_LISTING(address setCurator, address expectedCurator);
@@ -115,11 +118,12 @@ interface ICurator {
         address _owner,
         string memory _name,
         string memory _symbol,
-        address _curationPass,
         bool _pause,
         uint256 _curationLimit,
         address _renderer,
         bytes memory _rendererInitializer,
-        Listing[] memory _initialListings
+        Listing[] memory _initialListings,
+        address _accessControl,
+        bytes memory _accessControlInitializer          
     ) external;
 }

--- a/src/interfaces/ICurator.sol
+++ b/src/interfaces/ICurator.sol
@@ -59,10 +59,6 @@ interface ICurator {
     /// @notice Emitted when a listing is removed
     event ListingRemoved(address indexed curator, Listing listing);
 
-    // @notice The curation pass has been updated for the curation contract
-    // @dev Any users that have already curated something still can delete their curation.
-    // event CurationPassUpdated(address indexed owner, address curationPass);
-
     /// @notice A new accessControl is set
     event SetAccessControl(address);
 
@@ -80,12 +76,6 @@ interface ICurator {
 
     /// @notice This contract is scheduled to be frozen
     event ScheduledFreeze(uint256 timestamp);
-
-    // /// @notice Pass is required to manage curation but not held by attempted updater.
-    // error PASS_REQUIRED();
-
-    // @notice Only the curator of a listing (or owner) can manage that curation
-    // error ONLY_CURATOR();
 
     /// @notice Wrong curator for the listing when attempting to access the listing.
     error WRONG_CURATOR_FOR_LISTING(address setCurator, address expectedCurator);
@@ -122,8 +112,8 @@ interface ICurator {
         uint256 _curationLimit,
         address _renderer,
         bytes memory _rendererInitializer,
-        Listing[] memory _initialListings,
         address _accessControl,
-        bytes memory _accessControlInitializer          
+        bytes memory _accessControlInitializer,   
+        Listing[] memory _initialListings
     ) external;
 }

--- a/src/interfaces/ICuratorFactory.sol
+++ b/src/interfaces/ICuratorFactory.sol
@@ -12,6 +12,8 @@ interface ICuratorFactory {
     event RegisteredUpgradePath(address implFrom, address implTo);
     /// @notice Emitted when a new metadata renderer is set
     event HasNewMetadataRenderer(address);
+    /// @notice Emitted when a new accessControl is set
+    event HasNewAccessControl(address);
 
     /// @notice Getter to determine if a contract upgrade path is valid.
     function isValidUpgrade(address baseImpl, address newImpl) external view returns (bool);

--- a/src/interfaces/ICuratorInfo.sol
+++ b/src/interfaces/ICuratorInfo.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IAccessControlRegistry } from "onchain-modules/interfaces/IAccessControlRegistry.sol";
+import { IAccessControlRegistry } from "onchain/interfaces/IAccessControlRegistry.sol";
 
 interface ICuratorInfo {
     function name() external view returns (string memory);

--- a/src/interfaces/ICuratorInfo.sol
+++ b/src/interfaces/ICuratorInfo.sol
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import { IAccessControlRegistry } from "./interfaces/IAccessControlRegistry.sol";
+import { IAccessControlRegistry } from "onchain-modules/interfaces/IAccessControlRegistry.sol";
 
 interface ICuratorInfo {
     function name() external view returns (string memory);
 
     function accessControl() external view returns (IAccessControlRegistry);
-
-    // function curationPass() external view returns (IERC721Metadata);
 
     function owner() external view returns (address);
 }

--- a/src/interfaces/ICuratorInfo.sol
+++ b/src/interfaces/ICuratorInfo.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+// import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import { IAccessControlRegistry } from "./interfaces/IAccessControlRegistry.sol";
 
 interface ICuratorInfo {
     function name() external view returns (string memory);
 
-    function curationPass() external view returns (IERC721Metadata);
+    function accessControl() external view returns (IAccessControlRegistry);
+
+    // function curationPass() external view returns (IERC721Metadata);
 
     function owner() external view returns (address);
 }

--- a/src/renderer/SVGMetadataRenderer.sol
+++ b/src/renderer/SVGMetadataRenderer.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { IMetadataRenderer } from "../interfaces/IMetadataRenderer.sol";
-import { ICuratorInfo, IERC721Metadata } from "../interfaces/ICuratorInfo.sol";
+import { ICuratorInfo } from "../interfaces/ICuratorInfo.sol";
 import { IZoraDrop } from "../interfaces/IZoraDrop.sol";
 import { ICurator } from "../interfaces/ICurator.sol";
 
@@ -119,9 +119,9 @@ contract SVGMetadataRenderer is IMetadataRenderer {
         ICuratorInfo curation = ICuratorInfo(msg.sender);
         MetadataBuilder.JSONItem[] memory items = new MetadataBuilder.JSONItem[](3);
 
-        string memory curationName = "Untitled NFT";
+        string memory curationName = "Untitled Access Control";
 
-        try curation.curationPass().name() returns (string memory result) {
+        try curation.accessControl().name() returns (string memory result) {
             curationName = result;
         } catch {}
 
@@ -137,10 +137,7 @@ contract SVGMetadataRenderer is IMetadataRenderer {
             "The curation pass for this NFT is ",
             curationName,
             "\\n\\nThese NFTs only mark curations and are non-transferrable."
-            "\\n\\nView or manage this curation at: "
-            "https://public---assembly.com/curation/",
-            Strings.toHexString(msg.sender),
-            "\\n\\nA project of public assembly."
+            "\\n\\nA project of Public Assembly."
         );
         items[1].quote = true;
         items[2].key = MetadataJSONKeys.keyImage;
@@ -219,9 +216,7 @@ contract SVGMetadataRenderer is IMetadataRenderer {
             Strings.toHexString(listing.curator),
             "\\n\\nTo remove this curation, burn the NFT. "
             "\\n\\nThis NFT is non-transferrable. "
-            "\\n\\nView or manage this curation at: "
-            "https://public---assembly.com/curation/",
-            Strings.toHexString(msg.sender)
+            "\\n\\nA project of Public Assembly."
         );
         items[1].quote = true;
         items[2].key = MetadataJSONKeys.keyImage;


### PR DESCRIPTION
DO NOT MERGE !!!! - setting this pull request up to track updates that need to happen before it is ready

**Scope:**

This PR overhauls how access control is handled in Curator.sol. It allows a user to initialize their own access control pattern via an external contract, that can use arbitrary logic as long as it is compatible with this [interface](https://github.com/public-assembly/onchain-modules/blob/master/tokenized-access-control/src/interfaces/IAccessControlRegistry.sol). The accessControl pattern that has been set up is generic and can be used in any smart contract, and this curation protocol will be the first to use it

**To Dos Before Merging:**
1. Update all of the tests to check that this new access control works as intended. Should be done for at least 2 default access control scenarios, specifically [ERC721AccessControl](https://github.com/public-assembly/onchain-modules/blob/master/tokenized-access-control/src/Erc721AccessControl.sol) and [ERC20MinBalAccessControl](https://github.com/public-assembly/onchain-modules/blob/master/tokenized-access-control/src/Erc20MinBalAccessControl.sol). 
2. Related to 1, add tests to determine that upgrade paths for previously existing curation contracts ([neosound.xyz ](https://etherscan.io/address/0x52a64da96d0a0078bead9158198f3881c4fcd066)+ [public---assembly.com](https://etherscan.io/address/0xbc8db622af59f115cc228dff44d6b17478470ae2)) will not be broken post upgrade
3. Related to 2, make sure that listingRecord tokens are still rendering properly in marketplaces like Opensea from curation contracts that are intialized with the now updated SVGMetadataRenderer. Tokens should render like [this](https://opensea.io/assets/ethereum/0xbc8db622af59f115cc228dff44d6b17478470ae2/4) when working properly

**Questions to answer before merging:**
1. Should we add enum or public variables to make the accessControl logic more readable? Currently accessControl is being used in Curator.sol by comparing results of getAccessLevel to hardcoded access level numbers. In the current, its hard/impossible for users to know that 1 = curator, 2 = manager, 3 = admin (could also be helpful to add comments that explicitly state the functions each level has access to). <img width="737" alt="Screen Shot 2022-10-30 at 6 18 12 PM" src="https://user-images.githubusercontent.com/93691906/198912727-1580404e-1783-4bcb-859a-1be4c7824698.png">
2. Should authorizeUpgrade remain as onlyOwner, or be moved over to onlyOwnerOrAdminAccess? I have kept it as onlyOwner for now because until there is a better way of issuing non-transferrable tokens specifically for the Admin role, feels like a major security vulnerability to distribute passes that can be transferred/sold/stolen that enable upgrade access
3. Should owner be able to access curation functionality like in previous Curator.sol impl? Unlike in point 2, I have removed the ability for the contract owner to access the addListing function, which I think is actually ok because it makes the contract fully reliant on the accessControl functionality to deal with curation functions (not a security vulnerability)
4. A few storage gaps might needed to be updated due to changes in parameters. @iainnash I am completely unaware of how this works, so could use your eyes on this (see screenshot for the 2 places this shows up)
<img width="538" alt="Screen Shot 2022-10-30 at 6 24 00 PM" src="https://user-images.githubusercontent.com/93691906/198913143-8a1d5dee-9cf7-479d-8b36-82a826651d73.png">
5. Think we should push a "DefaultAccessControl.sol" file that can be used without an accessControlInitializer in the factory to provide a generic, onlyOwner based access control strategy. This can then be used as the default access control that is triggered if ppl pass the address(0) value + empty accessControlInitializer into the CuratorFactory 
6. *not related to upgrade* - CurationFactory uses the variable “ address curationManger” to initialize the owner of the proxy curation contract. Feels potentially confusing? Do we change it to curationContractOwner maybe? Dont really like that either...


 
